### PR TITLE
Add tag management to directorio app

### DIFF
--- a/backend/directorio/admin.py
+++ b/backend/directorio/admin.py
@@ -1,5 +1,15 @@
 from django.contrib import admin
-from .models import Cliente, Proveedor, Vendedor, Contacto, RelacionBlue
+from .models import (
+    Cliente,
+    Proveedor,
+    Vendedor,
+    Contacto,
+    RelacionBlue,
+    Tag,
+    ClienteTag,
+    ProveedorTag,
+    ContactoTag,
+)
 
 @admin.register(Cliente)
 class ClienteAdmin(admin.ModelAdmin):
@@ -35,9 +45,37 @@ class RelacionBlueAdmin(admin.ModelAdmin):
     list_filter = ('nivel', 'cliente', 'contacto')
     ordering = ('-created_at',)
 
+
+@admin.register(Tag)
+class TagAdmin(admin.ModelAdmin):
+    list_display = ('name', 'color_code', 'created_at')
+    list_filter = ('created_at',)
+    search_fields = ('name',)
+    readonly_fields = ('created_at', 'updated_at')
+    ordering = ('name',)
+
+@admin.register(ClienteTag)
+class ClienteTagAdmin(admin.ModelAdmin):
+    list_display = ('cliente', 'tag', 'created_at')
+    list_filter = ('tag', 'cliente')
+    readonly_fields = ('created_at',)
+
+@admin.register(ProveedorTag)
+class ProveedorTagAdmin(admin.ModelAdmin):
+    list_display = ('proveedor', 'tag', 'created_at')
+    list_filter = ('tag', 'proveedor')
+    readonly_fields = ('created_at',)
+
+@admin.register(ContactoTag)
+class ContactoTagAdmin(admin.ModelAdmin):
+    list_display = ('contacto', 'tag', 'created_at')
+    list_filter = ('tag', 'contacto')
+    readonly_fields = ('created_at',)
+
 # If you prefer a simpler registration without custom admin classes, you can use:
 # admin.site.register(Cliente)
 # admin.site.register(Proveedor)
 # admin.site.register(Vendedor)
 # admin.site.register(Contacto)
 # admin.site.register(RelacionBlue)
+

--- a/backend/directorio/migrations/0002_tagging.py
+++ b/backend/directorio/migrations/0002_tagging.py
@@ -1,0 +1,84 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('directorio', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Tag',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=50, unique=True)),
+                ('color_code', models.CharField(default='#4F46E5', max_length=20)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                'verbose_name': 'Etiqueta',
+                'verbose_name_plural': 'Etiquetas',
+                'ordering': ['name'],
+            },
+        ),
+        migrations.CreateModel(
+            name='ClienteTag',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('cliente', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='directorio.cliente')),
+                ('tag', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='directorio.tag')),
+            ],
+            options={
+                'verbose_name': 'Etiqueta de cliente',
+                'verbose_name_plural': 'Etiquetas de clientes',
+                'unique_together': {('cliente', 'tag')},
+            },
+        ),
+        migrations.CreateModel(
+            name='ProveedorTag',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('proveedor', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='directorio.proveedor')),
+                ('tag', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='directorio.tag')),
+            ],
+            options={
+                'verbose_name': 'Etiqueta de proveedor',
+                'verbose_name_plural': 'Etiquetas de proveedores',
+                'unique_together': {('proveedor', 'tag')},
+            },
+        ),
+        migrations.CreateModel(
+            name='ContactoTag',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('contacto', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='directorio.contacto')),
+                ('tag', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='directorio.tag')),
+            ],
+            options={
+                'verbose_name': 'Etiqueta de contacto',
+                'verbose_name_plural': 'Etiquetas de contactos',
+                'unique_together': {('contacto', 'tag')},
+            },
+        ),
+        migrations.AddField(
+            model_name='cliente',
+            name='tags',
+            field=models.ManyToManyField(blank=True, related_name='clientes', through='directorio.ClienteTag', to='directorio.tag'),
+        ),
+        migrations.AddField(
+            model_name='proveedor',
+            name='tags',
+            field=models.ManyToManyField(blank=True, related_name='proveedores', through='directorio.ProveedorTag', to='directorio.tag'),
+        ),
+        migrations.AddField(
+            model_name='contacto',
+            name='tags',
+            field=models.ManyToManyField(blank=True, related_name='contactos', through='directorio.ContactoTag', to='directorio.tag'),
+        ),
+    ]
+

--- a/backend/directorio/models.py
+++ b/backend/directorio/models.py
@@ -1,6 +1,27 @@
 # backend/directorio/models.py
 from django.db import models
-from .validators import validate_ruc_ecuatoriano, validate_telefono_ecuador, validate_email_corporativo
+from .validators import (
+    validate_ruc_ecuatoriano,
+    validate_telefono_ecuador,
+    validate_email_corporativo,
+)
+
+
+class Tag(models.Model):
+    """Etiquetas para clasificar clientes, proveedores y contactos"""
+
+    name = models.CharField(max_length=50, unique=True)
+    color_code = models.CharField(max_length=20, default="#4F46E5")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "Etiqueta"
+        verbose_name_plural = "Etiquetas"
+        ordering = ["name"]
+
+    def __str__(self) -> str:  # pragma: no cover - simple repr
+        return self.name
 
 class Cliente(models.Model):
     """Modelo para representar los clientes en el directorio"""
@@ -16,6 +37,12 @@ class Cliente(models.Model):
     direccion = models.CharField(max_length=255)
     nota = models.TextField(blank=True, null=True)
     activo = models.BooleanField(default=True)
+    tags = models.ManyToManyField(
+        Tag,
+        through="ClienteTag",
+        related_name="clientes",
+        blank=True,
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -38,6 +65,12 @@ class Proveedor(models.Model):
     telefono = models.CharField(max_length=20, validators=[validate_telefono_ecuador])
     tipo_primario = models.BooleanField(default=False)
     activo = models.BooleanField(default=True)
+    tags = models.ManyToManyField(
+        Tag,
+        through="ProveedorTag",
+        related_name="proveedores",
+        blank=True,
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -78,6 +111,12 @@ class Contacto(models.Model):
     ingerencia = models.CharField(max_length=255)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+    tags = models.ManyToManyField(
+        Tag,
+        through="ContactoTag",
+        related_name="contactos",
+        blank=True,
+    )
 
     def __str__(self):
         return self.nombre
@@ -85,6 +124,48 @@ class Contacto(models.Model):
     class Meta:
         verbose_name = "Contacto"
         verbose_name_plural = "Contactos"
+
+
+class ClienteTag(models.Model):
+    cliente = models.ForeignKey(Cliente, on_delete=models.CASCADE)
+    tag = models.ForeignKey(Tag, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ("cliente", "tag")
+        verbose_name = "Etiqueta de cliente"
+        verbose_name_plural = "Etiquetas de clientes"
+
+    def __str__(self) -> str:  # pragma: no cover - simple repr
+        return f"{self.cliente} - {self.tag}"
+
+
+class ProveedorTag(models.Model):
+    proveedor = models.ForeignKey(Proveedor, on_delete=models.CASCADE)
+    tag = models.ForeignKey(Tag, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ("proveedor", "tag")
+        verbose_name = "Etiqueta de proveedor"
+        verbose_name_plural = "Etiquetas de proveedores"
+
+    def __str__(self) -> str:  # pragma: no cover - simple repr
+        return f"{self.proveedor} - {self.tag}"
+
+
+class ContactoTag(models.Model):
+    contacto = models.ForeignKey(Contacto, on_delete=models.CASCADE)
+    tag = models.ForeignKey(Tag, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ("contacto", "tag")
+        verbose_name = "Etiqueta de contacto"
+        verbose_name_plural = "Etiquetas de contactos"
+
+    def __str__(self) -> str:  # pragma: no cover - simple repr
+        return f"{self.contacto} - {self.tag}"
 
 class RelacionBlue(models.Model):
     """Modelo para representar las relaciones entre clientes y contactos"""

--- a/backend/directorio/tests.py
+++ b/backend/directorio/tests.py
@@ -1,3 +1,49 @@
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Cliente, Proveedor, Contacto, Tag
+
+
+class TagModelTests(TestCase):
+    def test_create_tag(self):
+        tag = Tag.objects.create(name="VIP")
+        self.assertEqual(str(tag), "VIP")
+
+
+class TagRelationTests(TestCase):
+    def setUp(self):
+        # Crear objetos base sin FKs opcionales
+        self.cliente = Cliente.objects.create(
+            nombre="Cliente X",
+            alias="cX",
+            razon_social="Cliente X SA",
+            ruc="1717171717171",
+            email="contacto@company.com",
+            telefono="0999999999",
+            direccion="Dir",
+        )
+        self.proveedor = Proveedor.objects.create(
+            ruc="1818181818181",
+            razon_social="Prov SA",
+            nombre="Proveedor P",
+            direccion1="Dir1",
+            correo="prov@company.com",
+            telefono="0999999998",
+        )
+        self.contacto = Contacto.objects.create(
+            nombre="Juan",
+            alias="juan",
+            telefono="0999999997",
+            email="juan@company.com",
+            ingerencia="ventas",
+        )
+
+    def test_assign_tags(self):
+        tag = Tag.objects.create(name="Importante")
+        self.cliente.tags.add(tag)
+        self.proveedor.tags.add(tag)
+        self.contacto.tags.add(tag)
+
+        self.assertIn(tag, self.cliente.tags.all())
+        self.assertIn(tag, self.proveedor.tags.all())
+        self.assertIn(tag, self.contacto.tags.all())
+

--- a/backend/directorio/urls.py
+++ b/backend/directorio/urls.py
@@ -1,8 +1,12 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .views import (
-    ClienteViewSet, ProveedorViewSet, VendedorViewSet,
-    ContactoViewSet, RelacionBlueViewSet
+    ClienteViewSet,
+    ProveedorViewSet,
+    VendedorViewSet,
+    ContactoViewSet,
+    RelacionBlueViewSet,
+    TagViewSet,
 )
 
 router = DefaultRouter()
@@ -11,8 +15,10 @@ router.register(r'proveedores', ProveedorViewSet)
 router.register(r'vendedores', VendedorViewSet)
 router.register(r'contactos', ContactoViewSet)
 router.register(r'relaciones', RelacionBlueViewSet)
+router.register(r'tags', TagViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),
 ]
+
 

--- a/backend/directorio/views.py
+++ b/backend/directorio/views.py
@@ -7,13 +7,14 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 
-from .models import Cliente, Proveedor, Vendedor, Contacto, RelacionBlue
+from .models import Cliente, Proveedor, Vendedor, Contacto, RelacionBlue, Tag
 from .serializers import (
     ClienteSerializer, ClienteDetalladoSerializer,
     ProveedorSerializer, ProveedorDetalladoSerializer,
     VendedorSerializer,
     ContactoSerializer, ContactoDetalladoSerializer,
-    RelacionBlueSerializer
+    RelacionBlueSerializer,
+    TagSerializer
 )
 from .pagination import StandardResultsSetPagination, LargeResultsSetPagination, CustomLimitOffsetPagination
 # Utilizamos los permisos estándar de DRF en lugar de redefiniciones personalizadas
@@ -368,3 +369,17 @@ class RelacionBlueViewSet(viewsets.ModelViewSet):
             serializer = self.get_serializer(relaciones, many=True)
             return Response(serializer.data)
         return Response({"error": "Se requiere el parámetro contacto_id"}, status=status.HTTP_400_BAD_REQUEST)
+
+
+class TagViewSet(viewsets.ModelViewSet):
+    """API endpoint para gestionar etiquetas del directorio."""
+
+    queryset = Tag.objects.all()
+    serializer_class = TagSerializer
+    pagination_class = StandardResultsSetPagination
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ["name"]
+    ordering_fields = ["name", "created_at"]
+    permission_classes = [permissions.IsAuthenticated]
+    throttle_classes = [UserBurstRateThrottle, UserSustainedRateThrottle]
+


### PR DESCRIPTION
## Summary
- add Tag model with join tables for Cliente, Proveedor and Contacto
- expose tags via serializers and viewsets
- register tag endpoints and admin classes
- create migration and tests for tags

## Testing
- `pytest backend/directorio/tests.py -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `python3 backend/manage.py makemigrations directorio` *(fails: ModuleNotFoundError: No module named 'django')*